### PR TITLE
feat/db: orders last-activity view + docs

### DIFF
--- a/docs/orders-activity.md
+++ b/docs/orders-activity.md
@@ -1,0 +1,10 @@
+# Orders + Last Activity
+
+`v_orders_list_with_last_activity` joins each order with the most recent `activity_log` row.
+
+Adds:
+- `last_action`
+- `last_message`
+- `last_activity_at`
+
+Use in Orders table “Activity” column and Drawer header.

--- a/supabase/migrations/2025-08-16_orders_last_activity_view.sql
+++ b/supabase/migrations/2025-08-16_orders_last_activity_view.sql
@@ -1,0 +1,15 @@
+-- Helper view: last activity per order for lists/drawer
+create or replace view public.v_orders_list_with_last_activity as
+select
+  l.*, 
+  a.action     as last_action,
+  a.message    as last_message,
+  a.created_at as last_activity_at
+from public.v_orders_list l
+left join lateral (
+  select action, message, created_at
+  from public.activity_log
+  where order_id = l.id
+  order by created_at desc
+  limit 1
+) a on true;


### PR DESCRIPTION
Adds `v_orders_list_with_last_activity` view, which joins each order with the latest activity_log entry. Useful for Orders list and Order Drawer.

Includes `docs/orders-activity.md` documenting the new view and columns (last_action, last_message, last_activity_at).