### PR TITLE
feat(ui): add dev Orders demo page (no routing changes)

### DIFF
--- a/src/pages/OrdersDemo.jsx
+++ b/src/pages/OrdersDemo.jsx
@@ -1,0 +1,13 @@
+import OrdersTable from '../features/orders/OrdersTable';
+
+export default function OrdersDemoPage(){
+  return (
+    <div className="p-6">
+      <h1 className="text-xl font-semibold mb-4">Orders (from view)</h1>
+      <OrdersTable />
+      <p className="text-sm text-gray-500 mt-4">
+        Data source: v_orders_list_with_last_activity (sorted by priority then due_date)
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
Adds a developer-only page `src/pages/OrdersDemo.jsx` which renders `OrdersTable` against the `v_orders_list_with_last_activity` view. This page is useful for testing the orders list without modifying existing routes.